### PR TITLE
Feature/0003 admin header

### DIFF
--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -44,7 +44,8 @@ class HandleInertiaRequests extends Middleware
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
-                'user' => $request->user(),
+                'user' => $request->user('web'),
+                'admin' => $request->user('admin'), // guardを引数にしてユーザー名を取得
             ],
             'ziggy' => [
                 ...(new Ziggy)->toArray(),

--- a/src/resources/js/components/admin/AdminHeader.vue
+++ b/src/resources/js/components/admin/AdminHeader.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ElButton } from 'element-plus'
+import { Link, router } from '@inertiajs/vue3'
+
+const adminLogout = (): void => {
+  router.visit(route('admin.logout'), {
+    method: 'post', 
+    replace: true // 再読み込みをせずに即座にログイン画面へ遷移 戻るボタンで戻れなくなり、UXが向上
+  })
+}
+</script>
+<template>
+  <header class="w-full bg-gray-800 text-white px-6 py-4 flex items-center justify-between shadow">
+
+    <div class="flex items-center">
+      <Link :href="route('admin.dashboard')" class="text-lg font-bold tracking-wide mr-8">
+        CINEMA-HOUSE 管理者TOP
+      </Link>
+  
+      <nav class="space-x-6 text-sm font-medium hidden md:flex">
+        <Link href="#" class="hover:underline">映画一覧</Link >
+        <Link href="#" class="hover:underline">上映カレンダー</Link>
+        <Link href="#" class="hover:underline">ユーザー管理</Link>
+      </nav>
+    </div>
+
+    <div class="flex items-center space-x-4 text-sm">
+      <span>管理者: 管理者太郎</span>
+      <el-button size="small" type="info" plain v-on:click="adminLogout">ログアウト</el-button>
+    </div>
+  </header>
+</template>

--- a/src/resources/js/components/admin/AdminHeader.vue
+++ b/src/resources/js/components/admin/AdminHeader.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { ElButton } from 'element-plus'
-import { Link, router } from '@inertiajs/vue3'
+import { computed } from 'vue'
+import { Link, router, usePage } from '@inertiajs/vue3'
+
+// 管理者の名前を取得
+const page = usePage()
+const admin = computed(() => page.props.auth.admin)
 
 const adminLogout = (): void => {
   router.visit(route('admin.logout'), {
@@ -25,7 +30,7 @@ const adminLogout = (): void => {
     </div>
 
     <div class="flex items-center space-x-4 text-sm">
-      <span>管理者: 管理者太郎</span>
+      <span>管理者: {{ admin.name }}</span>
       <el-button size="small" type="info" plain v-on:click="adminLogout">ログアウト</el-button>
     </div>
   </header>

--- a/src/resources/js/layouts/AdminLayout.vue
+++ b/src/resources/js/layouts/AdminLayout.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import AdminHeader from '@/components/admin/AdminHeader.vue'
+</script>
+<template>
+  <div>
+    <AdminHeader />
+    <main class="p-6">
+      <slot />
+    </main>
+  </div>
+</template>

--- a/src/resources/js/pages/admin/Dashboard.vue
+++ b/src/resources/js/pages/admin/Dashboard.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import { Head, router  } from '@inertiajs/vue3'
+import AdminLayout from '@/layouts/AdminLayout.vue'
+
+// レイアウトを適用
+defineOptions({
+  layout: AdminLayout
+})
 
 const adminLogout = (): void => {
   router.visit(route('admin.logout'), {

--- a/src/resources/js/types/index.d.ts
+++ b/src/resources/js/types/index.d.ts
@@ -3,6 +3,7 @@ import type { Config } from 'ziggy-js';
 
 export interface Auth {
     user: User;
+    admin: Admin; // 管理者用の型定義を追記
 }
 
 export interface BreadcrumbItem {
@@ -26,6 +27,17 @@ export type AppPageProps<T extends Record<string, unknown> = Record<string, unkn
 };
 
 export interface User {
+    id: number;
+    name: string;
+    email: string;
+    avatar?: string;
+    email_verified_at: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+// Adminの型設計を追記
+export interface Admin {
     id: number;
     name: string;
     email: string;


### PR DESCRIPTION
### 概要
管理者用のヘッダー部分を実装

### 実施内容
- AdminHeader.vueコンポーネントを実装
- レイアウトに埋め込む仕様に変更。それに伴いAdminLayout.vueを実装
- 管理者名を共有データとして出力できるように実装。HandleInertiaRequestsに'web', 'admin'両方の認証情報を取得できるようにする
- typescriptの型宣言の警告が出ないようにsrc/resources/js/types/index.d.tsに型定義を追記

### 備考
