### PR TITLE
Feature/0005 genre enum

### DIFF
--- a/src/app/Enums/Genre.php
+++ b/src/app/Enums/Genre.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enums;
+
+enum Genre: int
+{
+    case Action = 1;
+    case Comedy = 2;
+    case Drama = 3;
+    case Horror = 4;
+    case Romance = 5;
+    case Other = 99;
+
+    /**
+     * 映画ジャンルのラベルを取得
+     */
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Action => 'アクション',
+            self::Comedy => 'コメディ',
+            self::Drama => 'ドラマ',
+            self::Horror => 'ホラー',
+            self::Romance => 'ロマンス',
+            self::Other => 'その他',
+        };
+    }
+
+    /**
+     * 全ての値を配列で取得
+     */
+    public static function values(): array
+    {
+        return array_map(fn(self $genre) => $genre->value, self::cases());
+    }
+
+    /**
+     * セレクトボックスなどで利用可能な形式の配列を返す
+     */
+    public static function options(): array
+    {
+        return array_map(fn(self $genre) => [
+            'value' => $genre->value,
+            'label' => $genre->getLabel(),
+        ], self::cases());
+    }
+}

--- a/src/database/factories/MovieFactory.php
+++ b/src/database/factories/MovieFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Enums\Genre;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Movie>
@@ -18,7 +19,7 @@ class MovieFactory extends Factory
     {
         return [
             'title' => fake()->sentence(3),
-            'genre' => $this->faker->numberBetween(0, 5),
+            'genre' => fake()->randomElement(Genre::cases())->value,
             'description' => fake()->paragraph(3),
         ];
     }


### PR DESCRIPTION
### 概要
映画ジャンルをEnumで管理できるようにする

### 実施内容
- `App\Enums\Genre` Enum を作成
  - `getLabel()` メソッドで日本語ラベルを返却
  - `values()` メソッドで全ての値を配列で返却
  - `options()` メソッドでセレクトボックス用の配列を返却
- `MovieFactory` を修正し、Genre Enum の値をランダムに生成するよう変更

### 備考
