### PR TITLE
Feature/0006 movie list display

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   app:

--- a/src/app/Http/Controllers/Admin/MovieController.php
+++ b/src/app/Http/Controllers/Admin/MovieController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class MovieController extends Controller
+{
+    public function index()
+    {
+        // MovieServiceクラスから映画一覧を取得
+        dd('test');
+    }
+}

--- a/src/app/Http/Controllers/Admin/MovieController.php
+++ b/src/app/Http/Controllers/Admin/MovieController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Services\Admin\MovieService;
+use Inertia\Inertia;
 
 class MovieController extends Controller
 {
@@ -22,6 +23,9 @@ class MovieController extends Controller
     public function index(Request $request)
     {
         $movies = $this->movieService->getMovies($request);
-        dd($movies);
+        
+        return Inertia::render('admin/movies/Index', [
+            'movies' => $movies,
+        ]);
     }
 }

--- a/src/app/Http/Controllers/Admin/MovieController.php
+++ b/src/app/Http/Controllers/Admin/MovieController.php
@@ -4,12 +4,24 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Services\Admin\MovieService;
 
 class MovieController extends Controller
 {
-    public function index()
+    protected $movieService;
+
+    public function __construct(MovieService $movieService)
     {
-        // MovieServiceクラスから映画一覧を取得
-        dd('test');
+        // MovieServiceクラスのインスタンスを生成
+        $this->movieService = $movieService;
+    }
+
+    /**
+     * 映画の一覧を表示
+     */
+    public function index(Request $request)
+    {
+        $movies = $this->movieService->getMovies($request);
+        dd($movies);
     }
 }

--- a/src/app/Models/Movie.php
+++ b/src/app/Models/Movie.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Enums\Genre;
 
 class Movie extends Model
 {
@@ -15,4 +16,11 @@ class Movie extends Model
         'genre',
         'description',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'genre' => Genre::class,
+        ];
+    }
 }

--- a/src/app/Services/Admin/MovieService.php
+++ b/src/app/Services/Admin/MovieService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\Admin;
+
+use App\Models\Movie;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class MovieService
+{
+    /**
+     * 映画の一覧を取得
+     */
+    public function getMovies(Request $request): LengthAwarePaginator
+    {
+        $query = Movie::query();
+
+        $movies = $query->select('id', 'title', 'description', 'genre')
+            ->orderBy('created_at', 'desc')
+            ->paginate(10)->withQueryString(); // クエリ文字列値をペジネーションリンクに追加する(検索用)
+        
+        return $movies;
+    }
+}

--- a/src/app/Services/Admin/MovieService.php
+++ b/src/app/Services/Admin/MovieService.php
@@ -19,6 +19,11 @@ class MovieService
             ->orderBy('created_at', 'desc')
             ->paginate(10)->withQueryString(); // クエリ文字列値をペジネーションリンクに追加する(検索用)
         
+        $movies->transform(function ($movie) {
+            $movie->genre_label = $movie->genre->getLabel(); // ジャンルのラベル取得
+            return $movie;
+        });
+
         return $movies;
     }
 }

--- a/src/resources/js/components/admin/AdminHeader.vue
+++ b/src/resources/js/components/admin/AdminHeader.vue
@@ -23,7 +23,7 @@ const adminLogout = (): void => {
       </Link>
   
       <nav class="space-x-6 text-sm font-medium hidden md:flex">
-        <Link href="#" class="hover:underline">映画一覧</Link >
+        <Link :href="route('admin.movies.index')" class="hover:underline">映画一覧</Link >
         <Link href="#" class="hover:underline">上映カレンダー</Link>
         <Link href="#" class="hover:underline">ユーザー管理</Link>
       </nav>

--- a/src/resources/js/pages/admin/movies/Index.vue
+++ b/src/resources/js/pages/admin/movies/Index.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+import AdminLayout from '@/layouts/AdminLayout.vue'
+
+defineOptions({
+  layout: AdminLayout
+})
+
+const props = defineProps<{
+  movies: {
+    data: { id: number; title: string; genre: number; description: string }[],
+    current_page: number,
+    last_page: number,
+    links: { url: string | null; label: string; active: boolean }[],
+  }
+}>()
+
+</script>
+<template>
+  <Head title="映画一覧" />
+  映画一覧
+</template>

--- a/src/resources/js/pages/admin/movies/Index.vue
+++ b/src/resources/js/pages/admin/movies/Index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3'
+import { Head, Link, router } from '@inertiajs/vue3'
 import AdminLayout from '@/layouts/AdminLayout.vue'
+import { ref, watch } from 'vue'
 
 defineOptions({
   layout: AdminLayout
@@ -8,15 +9,55 @@ defineOptions({
 
 const props = defineProps<{
   movies: {
-    data: { id: number; title: string; genre: number; description: string }[],
+    data: { id: number; title: string; genre: number; genre_label: string; description: string }[],
     current_page: number,
     last_page: number,
+    total: number,
     links: { url: string | null; label: string; active: boolean }[],
+    per_page: number,
   }
 }>()
+
+const currentPage = ref(props.movies.current_page)
+
+// props が更新されたら同期
+watch(() => props.movies.current_page, (val) => {
+  currentPage.value = val
+})
+
+const handlePageChange = (page: number) => {
+  router.get(route('admin.movies.index'), { page }, { preserveState: true }) // preserveState: true ページ遷移しても現在の状態を維持
+}
 
 </script>
 <template>
   <Head title="映画一覧" />
-  映画一覧
+  
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-6">映画一覧</h1>
+
+    <el-table :data="props.movies.data" border stripe class="w-full">
+      <el-table-column prop="title" label="タイトル" min-width="200" />
+      <el-table-column prop="genre_label" label="ジャンル" min-width="120" />
+      <el-table-column prop="description" label="説明文" min-width="300" show-overflow-tooltip />
+      <el-table-column label="操作" width="150">
+        <template #default="scope">
+          <Link href="#">
+            <el-button type="primary" size="small">詳細</el-button>
+          </Link>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <!-- ページネーション -->
+    <div class="flex justify-center mt-6">
+      <el-pagination background layout="prev, pager, next" 
+        :total="props.movies.total" 
+        v-model:current-page="currentPage"
+        :page-size="props.movies.per_page"
+        @current-change="handlePageChange"
+      />
+    </div>
+  
+  </div>
 </template>

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\Admin\AdminLoginController;
 use App\Http\Controllers\Admin\AdminDashboardController;
+use App\Http\Controllers\Admin\MovieController;
 
 // ------------------------------------------------------------------------------------------------
 /**
@@ -22,6 +23,10 @@ Route::middleware(['web', 'admin'])->group(function () {
     Route::middleware(['auth:admin'])->group(function () {
         Route::post('logout', [AdminLoginController::class, 'logout'])->name('logout');
         Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
+
+        Route::controller(MovieController::class)->group(function () {
+            Route::get('movies', 'index')->name('movies.index');
+        });
     });
 
 });


### PR DESCRIPTION
### 概要
管理者画面に映画一覧ページを実装  
Element Plus のテーブルコンポーネントを利用して、映画情報を一覧表示し、ページネーションを追加しています。

### 実施内容
- Admin/MovieController@index の実装
- MovieService にてジャンルラベルを付与する処理を追加
- Vue (Index.vue) に映画一覧テーブルを実装
  - ページネーション機能を実装し、ページ移動に対応

### 備考
詳細ボタンは現状ダミーリンク（`#`）です。後続タスクで詳細ページを実装予定です。