### PR TITLE
Feature/0010 screening store

### DIFF
--- a/src/app/Http/Controllers/Admin/MovieController.php
+++ b/src/app/Http/Controllers/Admin/MovieController.php
@@ -8,6 +8,8 @@ use App\Services\Admin\MovieService;
 use Inertia\Inertia;
 use App\Http\Requests\MovieSearchRequest;
 use App\Http\Requests\Admin\StoreMovieRequest;
+use App\Enums\Genre;
+use Inertia\Response;
 
 class MovieController extends Controller
 {
@@ -29,7 +31,7 @@ class MovieController extends Controller
         return Inertia::render('admin/movies/Index', [
             'movies' => $movies,
             'filters' => $request->only(['title', 'genre', 'description', 'search_type']),
-            'genres' => \App\Enums\Genre::options(),
+            'genres' => Genre::options(),
         ]);
     }
 
@@ -39,7 +41,7 @@ class MovieController extends Controller
     public function create()
     {
         return Inertia::render('admin/movies/Create', [
-            'genres' => \App\Enums\Genre::options(),
+            'genres' => Genre::options(),
         ]);
     }
 
@@ -56,8 +58,17 @@ class MovieController extends Controller
     /**
      * 映画の詳細を表示
      */
-    public function show($id)
+    public function show(int $id): Response
     {
-        dd($id);
+        $movie = $this->movieService->getMovieById($id);
+        
+        return Inertia::render('admin/movies/Show', [
+            'movie' => [
+                'id' => $movie->id,
+                'title' => $movie->title,
+                'genre_label' => $movie->genre->getLabel(),
+                'description' => $movie->description,
+            ],
+        ]);
     }
 }

--- a/src/app/Http/Controllers/Admin/MovieController.php
+++ b/src/app/Http/Controllers/Admin/MovieController.php
@@ -52,4 +52,12 @@ class MovieController extends Controller
 
         return redirect()->route('admin.movies.index')->with('success', '映画の新規登録が完了しました');
     }
+
+    /**
+     * 映画の詳細を表示
+     */
+    public function show($id)
+    {
+        dd($id);
+    }
 }

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Screening;
+use App\Models\Movie;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class ScreeningCalendarController extends Controller
 {
@@ -17,8 +19,23 @@ class ScreeningCalendarController extends Controller
     {
         $screenings = Screening::with('movie')->get();
 
-        return inertia('admin/screenings/Calendar', [
+        return inertia::render('admin/screenings/Calendar', [
             'screenings' => $screenings,
+        ]);
+    }
+
+    /**
+     * 上映スケジュールの新規登録画面を表示
+     */
+    public function create(int $movie_id): Response
+    {
+        $movie = Movie::findOrFail($movie_id);
+
+        return Inertia::render('admin/screenings/Create', [
+            'movie' => [
+                'id' => $movie->id,
+                'title' => $movie->title,
+            ],
         ]);
     }
 }

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -9,9 +9,17 @@ use App\Models\Movie;
 use Inertia\Inertia;
 use Inertia\Response;
 use App\Http\Requests\Admin\StoreScreeningRequest;
+use App\Services\Admin\ScreeningService;
 
 class ScreeningCalendarController extends Controller
 {
+
+    private $screeningService;
+
+    public function __construct(ScreeningService $screeningService)
+    {
+        $this->screeningService = $screeningService;
+    }
 
     /**
      * カレンダー表示ページ.
@@ -45,6 +53,10 @@ class ScreeningCalendarController extends Controller
      */
     public function store(StoreScreeningRequest $request)
     {
-        dd($request);
+        $validated = $request->only('movie_id', 'screening_date', 'start_time', 'end_time');
+
+        $this->screeningService->storeScreening($validated);
+        
+        return redirect()->route('admin.screenings.calendar')->with('success', '上映スケジュール新規登録が完了しました');
     }
 }

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -8,6 +8,7 @@ use App\Models\Screening;
 use App\Models\Movie;
 use Inertia\Inertia;
 use Inertia\Response;
+use App\Http\Requests\Admin\StoreScreeningRequest;
 
 class ScreeningCalendarController extends Controller
 {
@@ -37,5 +38,13 @@ class ScreeningCalendarController extends Controller
                 'title' => $movie->title,
             ],
         ]);
+    }
+
+    /**
+     * 上映スケジュールの新規登録処理
+     */
+    public function store(StoreScreeningRequest $request)
+    {
+        dd($request);
     }
 }

--- a/src/app/Http/Requests/Admin/StoreScreeningRequest.php
+++ b/src/app/Http/Requests/Admin/StoreScreeningRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class StoreScreeningRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'movie_id' => ['required', 'integer', 'exists:movies,id'],
+            'screening_date' => ['required', 'date', 'after_or_equal:tomorrow'],
+            'start_time' => ['required', 'date_format:H:i'],
+            'end_time' => ['required', 'date_format:H:i', 'after:start_time'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'screening_date' => '上映日',
+            'start_time' => '上映開始時間',
+            'end_time' => '上映終了時間',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'screening_date.after_or_equal' => '上映日には明日以降の日付を指定してください。',
+            'end_time.after' => '上映終了時間は上映開始時間よりも後に設定してください。',
+        ];
+    }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                if ($this->start_time < '09:00' || $this->start_time > '21:00') {
+                    $validator->errors()->add(
+                        'start_time',
+                        '上映開始時間は9:00から21:00の間で設定してください'
+                    );
+                }
+
+                if ($this->end_time > '23:30') {
+                    $validator->errors()->add(
+                        'end_time',
+                        '上映終了時間は23:30までに設定してください'
+                    );
+                }
+            }
+        ];
+    }
+}

--- a/src/app/Services/Admin/MovieService.php
+++ b/src/app/Services/Admin/MovieService.php
@@ -40,6 +40,17 @@ class MovieService
     }
 
     /**
+     * 映画の詳細を取得
+     */
+    public function getMovieById(int $id): Movie
+    {
+        $movie = Movie::select('id', 'title', 'description', 'genre')
+            ->findOrFail($id);
+
+        return $movie;
+    }
+
+    /**
      * 映画情報を検索するクエリを生成
      */
     private function searchMoviesQuery(Builder $query, Request $request): Builder

--- a/src/app/Services/Admin/ScreeningService.php
+++ b/src/app/Services/Admin/ScreeningService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Admin;
+use App\Models\Screening;
+
+class ScreeningService
+{
+    /**
+     * 上映スケジュールの新規登録
+     */
+    public function storeScreening(array $validated): void
+    {
+        // 日付 + 時刻を datetime に組み立て
+        $validated['start_time'] = $validated['screening_date'] . ' ' . $validated['start_time'] . ':00';
+        $validated['end_time']   = $validated['screening_date'] . ' ' . $validated['end_time'] . ':00';
+
+        // DBに不要なフィールドを削除
+        unset($validated['screening_date']);
+
+        Screening::create($validated);
+    }
+}

--- a/src/lang/ja/validation.php
+++ b/src/lang/ja/validation.php
@@ -17,7 +17,7 @@ return [
     'accepted_if' => 'The :attribute field must be accepted when :other is :value.',
     'active_url' => 'The :attribute field must be a valid URL.',
     'after' => 'The :attribute field must be a date after :date.',
-    'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
+    'after_or_equal' => ':attribute には :date 以降の日付を指定してください',
     'alpha' => 'The :attribute field must only contain letters.',
     'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
     'alpha_num' => 'The :attribute field must only contain letters and numbers.',

--- a/src/resources/js/pages/admin/movies/Index.vue
+++ b/src/resources/js/pages/admin/movies/Index.vue
@@ -136,7 +136,7 @@ const handlePageChange = (page: number) => {
       <el-table-column prop="description" label="説明文" min-width="300" show-overflow-tooltip />
       <el-table-column label="操作" width="150">
         <template #default="scope">
-          <Link href="#">
+          <Link :href="route('admin.movies.show', scope.row.id)" >
             <el-button type="primary" size="small">詳細</el-button>
           </Link>
         </template>
@@ -155,7 +155,7 @@ const handlePageChange = (page: number) => {
   </div>
 </template>
 <style scoped>
-.el-alert {
-  margin-bottom: 4px;
+:deep(.el-alert) {
+  margin-bottom: 8px;
 }
 </style>

--- a/src/resources/js/pages/admin/movies/Show.vue
+++ b/src/resources/js/pages/admin/movies/Show.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3'
+import AdminLayout from '@/layouts/AdminLayout.vue'
+
+defineOptions({
+  layout: AdminLayout
+})
+
+const props = defineProps<{
+  movie: {
+    id: number
+    title: string
+    genre_label: string
+    description: string
+  }
+}>()
+
+</script>
+<template>
+  <Head title="映画詳細情報" />
+
+  <div class="max-w-5xl mx-auto py-10">
+    <h1 class="text-3xl font-bold mb-6">映画詳細</h1>
+
+    <el-card shadow="never" class="mb-6">
+      <template #header>
+        <span class="font-semibold">映画情報</span>
+      </template>
+
+      <div class="space-y-3">
+        <p class="text-xl">
+          <span class="font-bold mr-2">タイトル: </span>
+          『{{ props.movie.title }}』
+        </p>
+
+        <p class="text-xl">
+          <span class="font-bold mr-2">ジャンル: </span>
+          {{ props.movie.genre_label }}
+        </p>
+
+        <p class="text-xl">
+          <span class="font-bold">説明文: </span>
+        </p>
+        <p class="whitespace-pre-line text-lg">
+          {{ props.movie.description }}
+        </p>
+      </div>
+    </el-card>
+
+    <div class="flex justify-between items-center">
+      <Link :href="route('admin.movies.index')">
+        <el-button type="info">映画一覧に戻る</el-button>
+      </Link>
+
+      <div class="flex gap-4">
+        <!-- 削除ボタン 後ほど実装 -->
+        <!-- <el-button type="danger">削除</el-button> -->
+
+        <!-- 上映スケジュール登録ボタン -->
+        <Link href="#">
+          <el-button type="primary">上映スケジュールを登録</el-button>
+        </Link>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/resources/js/pages/admin/movies/Show.vue
+++ b/src/resources/js/pages/admin/movies/Show.vue
@@ -57,7 +57,7 @@ const props = defineProps<{
         <!-- <el-button type="danger">削除</el-button> -->
 
         <!-- 上映スケジュール登録ボタン -->
-        <Link href="#">
+        <Link :href="route('admin.screenings.create', props.movie.id)">
           <el-button type="primary">上映スケジュールを登録</el-button>
         </Link>
       </div>

--- a/src/resources/js/pages/admin/screenings/Calendar.vue
+++ b/src/resources/js/pages/admin/screenings/Calendar.vue
@@ -37,6 +37,15 @@ const screeningsByDate = computed(() => {
   <div class="p-6">
     <h1 class="text-2xl font-bold mb-4">上映スケジュールカレンダー</h1>
 
+    <!-- フラッシュメッセージ -->
+    <el-alert
+      v-if="$page.props.flash.success"
+      :title="$page.props.flash.success"
+      type="success"
+      show-icon
+      closable
+    />
+
     <el-calendar v-model="selectedDate">
       <template #date-cell="{ data }" >
         <!-- 日付 -->

--- a/src/resources/js/pages/admin/screenings/Create.vue
+++ b/src/resources/js/pages/admin/screenings/Create.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3'
+import AdminLayout from '@/layouts/AdminLayout.vue'
+
+defineOptions({
+  layout: AdminLayout
+})
+
+const props = defineProps<{
+  movie: {
+    id: number
+    title: string
+  }
+}>()
+
+interface ScreeningForm {
+  movie_id: number
+  screening_date: string
+  start_time: string
+  end_time: string
+}
+
+const screeningForm = useForm<ScreeningForm>({
+  movie_id: props.movie.id,
+  screening_date: '',
+  start_time: '',
+  end_time: '',
+})
+
+const submit = () => {
+  console.log('confirm')
+}
+
+</script>
+<template>
+  <Head title="上映スケジュール新規登録" />
+
+  <div class="max-w-3xl mx-auto py-8">
+    <h1 class="text-2xl font-bold mb-6">上映スケジュール新規登録</h1>
+
+    <el-form label-position="top" class="space-y-6" @submit.prevent="submit">
+      <el-form-item label="映画タイトル">
+        <el-input :model-value="props.movie.title" disabled />
+      </el-form-item>
+
+      <el-form-item label="上映日付">
+        <el-date-picker
+          v-model="screeningForm.screening_date"
+          type="date"
+          placeholder="年/月/日"
+          style="width: 50%"
+          format="YYYY/MM/DD"
+          value-format="YYYY-MM-DD"
+        />
+      </el-form-item>
+
+      <el-form-item label="上映開始時間">
+        <div class="flex gap-2 w-1/2">
+          <el-time-select
+            v-model="screeningForm.start_time"
+            start="09:00"
+            step="00:30"
+            end="21:00"
+            placeholder="時刻を選択"
+            style="flex: 1"
+          />
+        </div>
+      </el-form-item>
+
+      <el-form-item label="上映終了時間">
+        <div class="flex gap-2 w-1/2">
+          <el-time-select
+            v-model="screeningForm.end_time"
+            start="09:00"
+            step="00:30"
+            end="23:30"
+            placeholder="時刻を選択"
+            style="flex: 1"
+          />
+        </div>
+      </el-form-item>
+
+      <div class="flex justify-start mt-8">
+        <el-button type="primary" size="large" @click="submit" :loading="screeningForm.processing">
+          登録
+        </el-button>
+      </div>
+    </el-form>
+  </div>
+</template>

--- a/src/resources/js/pages/admin/screenings/Create.vue
+++ b/src/resources/js/pages/admin/screenings/Create.vue
@@ -56,7 +56,7 @@ const handleOpenConfirm = async(formEl: FormInstance | undefined) => {
 
 // モーダルの送信処理
 const submitScreeningStore = () => {
-  screeningForm.post('#', {
+  screeningForm.post(route('admin.screenings.store', props.movie.id), {
     onSuccess: () => {
       confirmDialogVisible.value = false
     },
@@ -73,6 +73,15 @@ const submitScreeningStore = () => {
   <div class="max-w-3xl mx-auto py-8">
     <h1 class="text-2xl font-bold mb-6">上映スケジュール新規登録</h1>
 
+    <!-- バックエンド側のバリデーションエラーメッセージ -->
+    <el-alert v-if="Object.keys(screeningForm.errors).length" title="入力に不備があります。下記をご確認ください。" type="error" show-icon :closable="false" >
+      <ul class="text-sm text-red-700 list-disc list-inside">
+        <li v-for="(message, field) in screeningForm.errors" :key="field">
+          {{ message }}
+        </li>
+      </ul>
+    </el-alert>
+    
     <el-form 
       label-position="top" 
       class="space-y-6" 
@@ -151,3 +160,8 @@ const submitScreeningStore = () => {
     </el-form>
   </div>
 </template>
+<style scoped>
+:deep(.el-alert) {
+  margin-bottom: 8px;
+}
+</style>

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -34,6 +34,7 @@ Route::middleware(['web', 'admin'])->group(function () {
         
         Route::controller(ScreeningCalendarController::class)->group(function () {
             Route::get('screenings/calendar', 'index')->name('screenings.calendar');
+            Route::get('movies/{movie_id}/screenings/create', 'create')->name('screenings.create');
         });
     });
 

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -35,6 +35,7 @@ Route::middleware(['web', 'admin'])->group(function () {
         Route::controller(ScreeningCalendarController::class)->group(function () {
             Route::get('screenings/calendar', 'index')->name('screenings.calendar');
             Route::get('movies/{movie_id}/screenings/create', 'create')->name('screenings.create');
+            Route::post('movies/{movie_id}/screenings', 'store')->name('screenings.store');
         });
     });
 

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -29,6 +29,7 @@ Route::middleware(['web', 'admin'])->group(function () {
             Route::get('movies', 'index')->name('movies.index');
             Route::get('movies/create', 'create')->name('movies.create');
             Route::post('movies/store', 'store')->name('movies.store');
+            Route::get('movies/{id}', 'show')->name('movies.show');
         });
         
         Route::controller(ScreeningCalendarController::class)->group(function () {


### PR DESCRIPTION
### 概要
上映スケジュール新規登録機能を実装

### 実施内容
- 映画詳細ページから上映スケジュール登録に進むため詳細ページを実装
- 上映スケジュール新規登録画面（Vue）の作成
  - 上映日付・開始時間・終了時間を入力
  - バリデーションと確認モーダルを追加
- StoreScreeningRequest を作成し、サーバーサイドのバリデーションを実装
  - 上映日: 明日以降のみ許可
  - 開始時間: 09:00〜21:00
  - 終了時間: 開始時間より後かつ23:30まで
- ScreeningService を実装し、日付と時刻を結合して datetime 形式で保存
- ScreeningController@store を追加し、登録完了後は上映スケジュールカレンダーへリダイレクト

### 備考
