### PR TITLE
Feature/0011 seat table

### DIFF
--- a/src/app/Models/Screening.php
+++ b/src/app/Models/Screening.php
@@ -30,4 +30,9 @@ class Screening extends Model
     {
         return $this->belongsTo(Movie::class);
     }
+
+    public function seats()
+    {
+        return $this->hasMany(Seat::class);
+    }
 }

--- a/src/app/Models/Seat.php
+++ b/src/app/Models/Seat.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Seat extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'screening_id',
+        'user_id',
+        'row',
+        'number',
+        'is_reserved',
+    ];
+
+    public function screening()
+    {
+        return $this->belongsTo(Screening::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/app/Services/Admin/ScreeningService.php
+++ b/src/app/Services/Admin/ScreeningService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Admin;
 use App\Models\Screening;
+use Illuminate\Support\Facades\DB;
+use App\Models\Seat;
 
 class ScreeningService
 {
@@ -17,6 +19,28 @@ class ScreeningService
         // DBに不要なフィールドを削除
         unset($validated['screening_date']);
 
-        Screening::create($validated);
+        DB::transaction(function () use ($validated) {
+            $screening = Screening::create($validated);
+
+            $rows = range('A', 'B');
+            $numbers = range(1, 10);
+
+            $seats = [];
+            foreach ($rows as $row) {
+                foreach ($numbers as $number) {
+                    $seats[] = [
+                        'screening_id' => $screening->id,
+                        'row' => $row,
+                        'number' => $number,
+                        'is_reserved' => false,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+
+            Seat::insert($seats);
+        });
+
     }
 }

--- a/src/database/factories/SeatFactory.php
+++ b/src/database/factories/SeatFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Seat;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Seat>
+ */
+class SeatFactory extends Factory
+{
+    protected $model = Seat::class; 
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'screening_id' => null,
+            'user_id' => null, // デフォルトは未予約
+            'row' => fake()->randomElement(['A', 'B']),
+            'number' => fake()->numberBetween(1, 10),
+            'is_reserved' => false,
+        ];
+    }
+}

--- a/src/database/migrations/2025_09_27_154142_create_seats_table.php
+++ b/src/database/migrations/2025_09_27_154142_create_seats_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seats', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('screening_id')->constrained()->cascadeOnDelete(); // 上映に紐付く
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete(); // ユーザーに紐付く
+            $table->string('row');  // 行 (例: A, B, C)
+            $table->unsignedInteger('number'); // 座席番号
+            $table->boolean('is_reserved')->default(false); // 予約済みかどうか
+            $table->timestamps();
+
+            // 同じ上映で同じ座席は重複不可
+            $table->unique(['screening_id', 'row', 'number']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seats');
+    }
+};

--- a/src/database/seeders/DevelopmentSeeder.php
+++ b/src/database/seeders/DevelopmentSeeder.php
@@ -32,6 +32,7 @@ class DevelopmentSeeder extends Seeder
         $this->call([
             MovieSeeder::class,
             ScreeningSeeder::class,
+            SeatSeeder::class,
         ]);
     }
 }

--- a/src/database/seeders/SeatSeeder.php
+++ b/src/database/seeders/SeatSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Screening;
+use App\Models\Seat;
+
+class SeatSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $screenings = Screening::all();
+        $rows = ['A', 'B']; // 行
+        $seatsPerRow = 10;       // 1行あたりの席数
+
+        foreach ($screenings as $screening) {
+            $seats = [];
+
+            foreach ($rows as $row) {
+                for ($number = 1; $number <= $seatsPerRow; $number++) {
+                    $seats[] = [
+                        'screening_id' => $screening->id,
+                        'row' => $row,
+                        'number' => $number,
+                        'is_reserved' => false,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ];
+                }
+            }
+
+            Seat::insert($seats); // 一括挿入で座席を生成
+        }
+    }
+}


### PR DESCRIPTION
### 概要
上映スケジュールに紐づく座席テーブルを実装し、上映登録時に自動生成されるように対応

### 実施内容
- `seats` テーブルのマイグレーションを追加
  - `screening_id` / `user_id` 外部キーを設定
  - A〜B行 × 10列の座席を一意制約付きで定義
- `SeatSeeder` を追加し、上映ごとに未予約座席を自動投入
- `ScreeningService` を修正し、上映スケジュール登録時に座席レコードを自動生成

### 備考
- 将来的に予約済みデータをSeederでランダム生成する予定だが、現段階では全席未予約で固定
