### PR TITLE
Feature/0012 seat status admin

### DIFF
--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -62,6 +62,7 @@ class ScreeningCalendarController extends Controller
 
     public function show(int $screening_id)
     {
-        dd($screening_id);
+        $screening = $this->screeningService->getScreeningDetails($screening_id);
+        dd($screening);
     }
 }

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -60,9 +60,12 @@ class ScreeningCalendarController extends Controller
         return redirect()->route('admin.screenings.calendar')->with('success', '上映スケジュール新規登録が完了しました');
     }
 
-    public function show(int $screening_id)
+    public function show(int $screening_id): Response
     {
         $screening = $this->screeningService->getScreeningDetails($screening_id);
-        dd($screening);
+        
+        return Inertia::render('admin/screenings/Show', [
+            'screening' => $screening, 
+        ]);
     }
 }

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -59,4 +59,9 @@ class ScreeningCalendarController extends Controller
         
         return redirect()->route('admin.screenings.calendar')->with('success', '上映スケジュール新規登録が完了しました');
     }
+
+    public function show(int $screening_id)
+    {
+        dd($screening_id);
+    }
 }

--- a/src/resources/js/pages/admin/screenings/Calendar.vue
+++ b/src/resources/js/pages/admin/screenings/Calendar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import AdminLayout from '@/layouts/AdminLayout.vue'
-import { Head } from '@inertiajs/vue3'
+import { Head, Link } from '@inertiajs/vue3'
 import { ref, computed } from 'vue'
 import dayjs from 'dayjs' // JavaScriptの日付処理・操作のライブラリ
 
@@ -70,9 +70,11 @@ const screeningsByDate = computed(() => {
                 上映時間： {{ dayjs(s.start_time).format('HH:mm') }} ～ {{ dayjs(s.end_time).format('HH:mm') }}
               </template>
 
-              <span class="cursor-pointer text-xs text-blue-600 underline">
-                {{ s.movie.title }}
-              </span>
+              <Link :href="route('admin.screenings.show', s.id)">
+                <span class="cursor-pointer text-xs text-blue-600 underline">
+                  {{ s.movie.title }}
+                </span>
+              </Link>
 
             </el-tooltip>
           </li>

--- a/src/resources/js/pages/admin/screenings/Show.vue
+++ b/src/resources/js/pages/admin/screenings/Show.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+import AdminLayout from '@/layouts/AdminLayout.vue'
+
+defineOptions({
+  layout: AdminLayout
+})
+
+// Laravel側から渡されるprops
+const props = defineProps<{
+  screening: {
+    screening_id: number
+    screening_date: string
+    start_time: string
+    end_time: string
+    movie: {
+      title: string
+      genre: string
+      genre_label: string
+    }
+    seats: Record<string, {
+      id: number
+      row: string
+      number: number
+      is_reserved: boolean
+      user_id?: number | null
+    }[]>
+  }
+}>()
+
+</script>
+<template>
+  <Head title="上映スケジュール詳細" />
+
+  <div class="max-w-6xl mx-auto py-10">
+    <el-card shadow="always" class="mb-6" header-class="bg-blue-600 text-white" >
+      <template #header >
+        <span class="font-semibold">上映スケジュール詳細</span>
+      </template>
+
+      <div class="space-y-1 mb-3">
+        <p class="text-lg font-semibold">
+          <strong class="mr-2">映画タイトル:</strong>
+           『{{ props.screening.movie.title }}』
+        </p>
+
+        <p class="text-base text-gray-600">
+          <strong class="mr-2">ジャンル:</strong>
+            {{ props.screening.movie.genre_label }}
+        </p>
+        <p class="text-base text-gray-600">
+          <strong class="mr-2">上映日:</strong>
+            {{ props.screening.screening_date }}
+        </p>
+        <p class="text-base text-gray-600">
+          <strong class="mr-2">上映開始:</strong>
+            {{ props.screening.start_time }}
+        </p>
+        <p class="text-base text-gray-600">
+          <strong class="mr-2">上映終了:</strong>
+            {{ props.screening.end_time }}
+        </p>
+      </div>
+
+      <div class="border-t-1 border-gray-300"></div>
+
+      <!-- 凡例 -->
+      <h3 class="my-2 font-bold">座席予約状況</h3>
+      <p class="text-sm text-gray-500 mb-3">
+        緑色: 空席 / 灰色: 予約済み
+      </p>
+
+      <!-- 座席表 -->
+      <div v-for="(rowSeats, row) in props.screening.seats" :key="row" class="flex items-center mb-3">
+        <span class="w-6 font-bold">{{ row }}</span>
+
+        <div class="grid grid-cols-10 gap-3">
+          <div
+            v-for="seat in rowSeats"
+            :key="seat.id"
+            class="w-10 h-10 flex items-center justify-center rounded text-white text-sm"
+            :class="{
+              'bg-green-600': !seat.is_reserved,
+              'bg-gray-400': seat.is_reserved
+            }"
+          >
+            {{ seat.number }}
+          </div>
+        </div>
+      </div>
+
+    </el-card>
+  </div>
+  
+</template>

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -36,6 +36,7 @@ Route::middleware(['web', 'admin'])->group(function () {
             Route::get('screenings/calendar', 'index')->name('screenings.calendar');
             Route::get('movies/{movie_id}/screenings/create', 'create')->name('screenings.create');
             Route::post('movies/{movie_id}/screenings', 'store')->name('screenings.store');
+            Route::get('screenings/{screening_id}', 'show')->name('screenings.show');
         });
     });
 


### PR DESCRIPTION
### 概要
管理者側で上映スケジュールの詳細を確認できる画面を実装し、座席の予約状況を可視化。

### 実施内容
- `Show.vue` を作成し上映詳細画面を追加
  - 映画タイトル・ジャンル・上映日・上映時間を表示
  - 座席を行ごとにグリッドで表示
  - 空席は緑、予約済みは灰色で色分け
- Laravel 側でデータを行ごとに整形して Vue 側へ返却

### 備考
- 凡例はテキストで表示（今後 Element Plus のタグに置き換え検討）
