### PR TITLE
Improvement/0002 refactor screening grouping backend

### DIFF
--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -26,6 +26,8 @@ class ScreeningCalendarController extends Controller
      */
     public function index()
     {
+        $this->screeningService->getGroupedScreenings();
+
         $screenings = Screening::with('movie')->get();
 
         return inertia::render('admin/screenings/Calendar', [

--- a/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
+++ b/src/app/Http/Controllers/Admin/ScreeningCalendarController.php
@@ -26,12 +26,10 @@ class ScreeningCalendarController extends Controller
      */
     public function index()
     {
-        $this->screeningService->getGroupedScreenings();
-
-        $screenings = Screening::with('movie')->get();
+        $screeningsByDate = $this->screeningService->getGroupedScreenings();
 
         return inertia::render('admin/screenings/Calendar', [
-            'screenings' => $screenings,
+            'screeningsByDate' => $screeningsByDate,
         ]);
     }
 

--- a/src/app/Http/Controllers/User/ScreeningController.php
+++ b/src/app/Http/Controllers/User/ScreeningController.php
@@ -22,10 +22,10 @@ class ScreeningController extends Controller
      */
     public function index()
     {
-        $screenings = Screening::with('movie')->get();
+        $screeningsByDate = $this->screeningService->getGroupedScreenings();
 
         return inertia::render('user/screenings/Calendar', [
-            'screenings' => $screenings,
+            'screeningsByDate' => $screeningsByDate,
         ]);
     }
 

--- a/src/app/Models/Screening.php
+++ b/src/app/Models/Screening.php
@@ -26,6 +26,12 @@ class Screening extends Model
         ];
     }
 
+    // 上映開始時間から日付だけを取得
+    public function getScreeningDateAttribute()
+    {
+        return $this->start_time->toDateString(); // "2025-10-03"
+    }
+
     public function movie()
     {
         return $this->belongsTo(Movie::class);

--- a/src/app/Services/Admin/ScreeningService.php
+++ b/src/app/Services/Admin/ScreeningService.php
@@ -6,9 +6,22 @@ use Illuminate\Support\Facades\DB;
 use App\Models\Seat;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Collection;
 
 class ScreeningService
 {
+    /**
+     * 上映スケジュールを日付ごとにまとめる
+     */
+    public function getGroupedScreenings(): Collection
+    {
+        return Screening::with('movie')
+            ->orderBy('start_time')
+            ->get()
+            ->groupBy(fn($s) => $s->start_time->toDateString()); // 日付ごとにグループ化
+
+    }
+
     /**
      * 上映スケジュールの新規登録
      */

--- a/src/resources/js/components/ScreeningCalendar.vue
+++ b/src/resources/js/components/ScreeningCalendar.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+import dayjs from 'dayjs' // JavaScriptの日付処理・操作のライブラリ
+import { ref } from 'vue'
+
+defineProps<{
+  screeningsByDate: Record<
+    string,
+    {
+      id: number
+      start_time: string
+      end_time: string
+      movie: { id: number; title: string }
+    }[]
+  >
+  routeName: string // リンク先のルート名 (admin / user で切り替える用)
+}>()
+
+const selectedDate = ref(new Date())
+</script>
+
+<template>
+  <el-calendar v-model="selectedDate">
+    <template #date-cell="{ data }">
+      <div class="text-sm font-medium">
+        {{ dayjs(data.day).format('D日') }}
+      </div>
+
+      <ul class="mt-1 space-y-1">
+        <li
+          v-for="s in screeningsByDate[data.day] || []"
+          :key="s.id"
+          class="truncate"
+        >
+          <el-tooltip effect="dark" placement="top">
+            <template #content>
+              タイトル：『{{ s.movie.title }}』<br />
+              上映時間： {{ dayjs(s.start_time).format('HH:mm') }}
+              ～ {{ dayjs(s.end_time).format('HH:mm') }}
+            </template>
+
+            <Link :href="route(routeName, s.id)">
+              <span class="cursor-pointer text-xs text-blue-600 underline">
+                {{ s.movie.title }}
+              </span>
+            </Link>
+          </el-tooltip>
+        </li>
+      </ul>
+    </template>
+  </el-calendar>
+</template>
+
+<style scoped>
+:deep(.el-calendar-table .el-calendar-day) {
+  height: 150px;
+}
+</style>

--- a/src/resources/js/pages/admin/screenings/Calendar.vue
+++ b/src/resources/js/pages/admin/screenings/Calendar.vue
@@ -11,24 +11,16 @@ defineOptions({
 const selectedDate = ref(new Date()) // 現在の日付と時刻を取得
 
 const props = defineProps<{
-  screenings: {
-    id: number
-    start_time: string
-    end_time: string
-    movie: { id: number; title: string }
-  }[]
+  screeningsByDate: Record<
+    string,
+    {
+      id: number
+      start_time: string
+      end_time: string
+      movie: { id: number; title: string }
+    }[]
+  >
 }>()
-
-// 日付文字列ごとに上映スケジュールをまとめる
-const screeningsByDate = computed(() => {
-  const map: { [key: string]: typeof props.screenings } = {}
-  props.screenings.forEach(sc => {
-    const dateKey = dayjs(sc.start_time).format('YYYY-MM-DD')
-    if (!map[dateKey]) map[dateKey] = []
-    map[dateKey].push(sc)
-  })
-  return map
-})
 
 </script>
 <template>
@@ -56,7 +48,7 @@ const screeningsByDate = computed(() => {
         <!-- 上映スケジュール -->
         <ul class="mt-1 space-y-1">
           <li
-            v-for="s in screeningsByDate[data.day] || []"
+            v-for="s in props.screeningsByDate[data.day] || []"
             :key="s.id"
             class="truncate"
           >

--- a/src/resources/js/pages/admin/screenings/Calendar.vue
+++ b/src/resources/js/pages/admin/screenings/Calendar.vue
@@ -1,25 +1,15 @@
 <script setup lang="ts">
 import AdminLayout from '@/layouts/AdminLayout.vue'
-import { Head, Link } from '@inertiajs/vue3'
-import { ref, computed } from 'vue'
-import dayjs from 'dayjs' // JavaScriptの日付処理・操作のライブラリ
+import { Head } from '@inertiajs/vue3'
+import ScreeningCalendar from '@/components/ScreeningCalendar.vue'
+import type { Screening } from '@/types/screening'
 
 defineOptions({
   layout: AdminLayout
 })
 
-const selectedDate = ref(new Date()) // 現在の日付と時刻を取得
-
-const props = defineProps<{
-  screeningsByDate: Record<
-    string,
-    {
-      id: number
-      start_time: string
-      end_time: string
-      movie: { id: number; title: string }
-    }[]
-  >
+defineProps<{
+  screeningsByDate: Record<string, Screening[]>
 }>()
 
 </script>
@@ -38,47 +28,8 @@ const props = defineProps<{
       closable
     />
 
-    <el-calendar v-model="selectedDate">
-      <template #date-cell="{ data }" >
-        <!-- 日付 -->
-        <div class="text-sm font-medium">
-          {{ dayjs(data.day).format('D日') }}
-        </div>
-
-        <!-- 上映スケジュール -->
-        <ul class="mt-1 space-y-1">
-          <li
-            v-for="s in props.screeningsByDate[data.day] || []"
-            :key="s.id"
-            class="truncate"
-          >
-            <el-tooltip
-              effect="dark"
-              placement="top"
-            >
-
-              <template #content>
-                タイトル： 『{{ s.movie.title }}』<br />
-                上映時間： {{ dayjs(s.start_time).format('HH:mm') }} ～ {{ dayjs(s.end_time).format('HH:mm') }}
-              </template>
-
-              <Link :href="route('admin.screenings.show', s.id)">
-                <span class="cursor-pointer text-xs text-blue-600 underline">
-                  {{ s.movie.title }}
-                </span>
-              </Link>
-
-            </el-tooltip>
-          </li>
-        </ul>
-
-      </template>
-    </el-calendar>
+    <!-- カレンダーコンポーネント -->
+    <ScreeningCalendar :screeningsByDate="screeningsByDate" routeName="admin.screenings.show" />
+    
   </div>
 </template>
-<style scoped>
-/* カレンダーセルの日付枠サイズを拡張 */
-:deep(.el-calendar-table .el-calendar-day) {
-  height: 150px; /* デフォルトは60px前後 */
-}
-</style>

--- a/src/resources/js/pages/user/screenings/Calendar.vue
+++ b/src/resources/js/pages/user/screenings/Calendar.vue
@@ -11,24 +11,16 @@ defineOptions({
 const selectedDate = ref(new Date()) // 現在の日付と時刻を取得
 
 const props = defineProps<{
-  screenings: {
-    id: number
-    start_time: string
-    end_time: string
-    movie: { id: number; title: string }
-  }[]
+  screeningsByDate: Record<
+    string,
+    {
+      id: number
+      start_time: string
+      end_time: string
+      movie: { id: number; title: string }
+    }[]
+  >
 }>()
-
-// 日付文字列ごとに上映スケジュールをまとめる
-const screeningsByDate = computed(() => {
-  const map: { [key: string]: typeof props.screenings } = {}
-  props.screenings.forEach(sc => {
-    const dateKey = dayjs(sc.start_time).format('YYYY-MM-DD')
-    if (!map[dateKey]) map[dateKey] = []
-    map[dateKey].push(sc)
-  })
-  return map
-})
 
 </script>
 <template>
@@ -56,7 +48,7 @@ const screeningsByDate = computed(() => {
         <!-- 上映スケジュール -->
         <ul class="mt-1 space-y-1">
           <li
-            v-for="s in screeningsByDate[data.day] || []"
+            v-for="s in props.screeningsByDate[data.day] || []"
             :key="s.id"
             class="truncate"
           >

--- a/src/resources/js/pages/user/screenings/Calendar.vue
+++ b/src/resources/js/pages/user/screenings/Calendar.vue
@@ -1,25 +1,15 @@
 <script setup lang="ts">
 import UserLayout from '@/layouts/UserLayout.vue'
-import { Head, Link } from '@inertiajs/vue3'
-import { ref, computed } from 'vue'
-import dayjs from 'dayjs' // JavaScriptの日付処理・操作のライブラリ
+import { Head } from '@inertiajs/vue3'
+import ScreeningCalendar from '@/components/ScreeningCalendar.vue'
+import type { Screening } from '@/types/screening'
 
 defineOptions({
   layout: UserLayout
 })
 
-const selectedDate = ref(new Date()) // 現在の日付と時刻を取得
-
-const props = defineProps<{
-  screeningsByDate: Record<
-    string,
-    {
-      id: number
-      start_time: string
-      end_time: string
-      movie: { id: number; title: string }
-    }[]
-  >
+defineProps<{
+  screeningsByDate: Record<string, Screening[]>
 }>()
 
 </script>
@@ -38,47 +28,8 @@ const props = defineProps<{
       closable
     />
 
-    <el-calendar v-model="selectedDate">
-      <template #date-cell="{ data }" >
-        <!-- 日付 -->
-        <div class="text-sm font-medium">
-          {{ dayjs(data.day).format('D日') }}
-        </div>
+    <!-- カレンダーコンポーネント -->
+    <ScreeningCalendar :screeningsByDate="screeningsByDate" routeName="user.screenings.show" />
 
-        <!-- 上映スケジュール -->
-        <ul class="mt-1 space-y-1">
-          <li
-            v-for="s in props.screeningsByDate[data.day] || []"
-            :key="s.id"
-            class="truncate"
-          >
-            <el-tooltip
-              effect="dark"
-              placement="top"
-            >
-
-              <template #content>
-                タイトル： 『{{ s.movie.title }}』<br />
-                上映時間： {{ dayjs(s.start_time).format('HH:mm') }} ～ {{ dayjs(s.end_time).format('HH:mm') }}
-              </template>
-
-              <Link :href="route('user.screenings.show', s.id)">
-                <span class="cursor-pointer text-xs text-blue-600 underline">
-                  {{ s.movie.title }}
-                </span>
-              </Link>
-
-            </el-tooltip>
-          </li>
-        </ul>
-
-      </template>
-    </el-calendar>
   </div>
 </template>
-<style scoped>
-/* カレンダーセルの日付枠サイズを拡張 */
-:deep(.el-calendar-table .el-calendar-day) {
-  height: 150px; /* デフォルトは60px前後 */
-}
-</style>

--- a/src/resources/js/types/screening.ts
+++ b/src/resources/js/types/screening.ts
@@ -1,0 +1,7 @@
+
+export type Screening = {
+  id: number
+  start_time: string
+  end_time: string
+  movie: { id: number; title: string }
+}


### PR DESCRIPTION
### 概要
上映スケジュールのカレンダー表示処理を整理し、バックエンド側で日付ごとにグルーピングするよう変更。  
また、フロントエンドでは共通コンポーネント化と型定義の厳密化を行い、Admin/User 両画面で再利用可能にした。

### 実施内容
- バックエンド側で日付ごとにグルーピングして Vue に渡すよう変更
- Vue 側で `Screening` 型を定義し、`Record<string, Screening[]>` としてデータを受け取る仕様に変更
- 上映カレンダー表示部分を `ScreeningCalendar` コンポーネントとして共通化
- Admin/User 両画面で共通コンポーネントを利用するよう調整

### 備考

