### PR TITLE
Feature/0032 add admin movie tests

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,13 +5,16 @@ RUN apt-get update && apt-get install -y \
     curl \
     libzip-dev \
     libpng-dev \
+    libjpeg-dev \
+    libwebp-dev \
     libonig-dev \
     libxml2-dev \
     zip \
     unzip \
     vim \
-  && apt-get clean \
-  && docker-php-ext-install pdo_mysql mbstring zip gd
+  && docker-php-ext-configure gd --with-jpeg --with-webp \
+  && docker-php-ext-install pdo_mysql mbstring zip gd \
+  && apt-get clean
 
 # Composerのインストール（公式イメージからコピー）
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/src/database/factories/AdminFactory.php
+++ b/src/database/factories/AdminFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use App\Models\Admin;
 
 /**
@@ -11,7 +13,12 @@ use App\Models\Admin;
 class AdminFactory extends Factory
 {
     protected $model = Admin::class;
-    
+
+    /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
     /**
      * Define the model's default state.
      *
@@ -20,7 +27,10 @@ class AdminFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'password' => static::$password ??= Hash::make('password'),
+            'remember_token' => Str::random(10),
         ];
     }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -53,4 +53,36 @@ class MovieStoreTest extends TestCase
         $this->assertNotNull($movie->poster_path);
         Storage::disk('public')->assertExists($movie->poster_path);
     }
+
+    /**
+     * ポスター画像なしで映画を登録できること
+     */
+    public function test_can_store_movie_without_poster(): void
+    {
+        // 管理者を作成してログイン
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => 'ポスターなし映画',
+            'genre' => 2,  // Comedy
+            'description' => 'ポスター画像なしの映画です。',
+            // poster は指定しない
+        ]);
+
+        // リダイレクト確認
+        $response->assertRedirect(route('admin.movies.index'));
+
+        // フラッシュメッセージ確認
+        $response->assertSessionHas('success', '映画の新規登録が完了しました');
+
+        // データベースに保存されたことを確認
+        $this->assertDatabaseHas('movies', [
+            'title' => 'ポスターなし映画',
+            'genre' => 2,
+            'description' => 'ポスター画像なしの映画です。',
+            'poster_path' => null,  // poster_path が null であることを確認
+        ]);
+    }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -213,4 +213,34 @@ class MovieStoreTest extends TestCase
             'title' => '不正ポスター映画',
         ]);
     }
+
+    /**
+     * ポスター画像サイズが上限を超える場合、登録できないこと
+     */
+    public function test_validation_fails_when_poster_size_exceeds_limit(): void
+    {
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $oversizedPoster = UploadedFile::fake()->create('poster.jpg', 3000, 'image/jpeg');
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => '大きすぎるポスター映画',
+            'genre' => 1,
+            'description' => 'ポスター画像が上限を超える場合のテストです。',
+            'poster' => $oversizedPoster,
+        ]);
+
+        // バリデーションエラーでリダイレクトされることを確認
+        $response->assertRedirect();
+
+        // poster フィールドのエラーを確認
+        $response->assertSessionHasErrors(['poster']);
+
+        // データベースに保存されていないことを確認
+        $this->assertDatabaseMissing('movies', [
+            'title' => '大きすぎるポスター映画',
+        ]);
+    }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Admin;
+use App\Models\Movie;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class MovieStoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * ポスター画像ありで映画を登録できること
+     */
+    public function test_can_store_movie_with_poster(): void
+    {
+        Storage::fake('public');
+
+        // 管理者を作成してログイン
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        // リクエストボディを準備
+        $posterImage = UploadedFile::fake()->image('poster.jpg', 200, 300);
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => 'テスト映画',
+            'genre' => 1,  // Action
+            'description' => 'これはテスト映画の説明です。',
+            'poster' => $posterImage,
+        ]);
+
+        // リダイレクト確認
+        $response->assertRedirect(route('admin.movies.index'));
+
+        // フラッシュメッセージ確認
+        $response->assertSessionHas('success', '映画の新規登録が完了しました');
+
+        // データベースに保存されたことを確認
+        $this->assertDatabaseHas('movies', [
+            'title' => 'テスト映画',
+            'genre' => 1,
+            'description' => 'これはテスト映画の説明です。',
+        ]);
+
+        // ストレージに画像が保存されたことを確認
+        $movie = Movie::where('title', 'テスト映画')->first();
+        $this->assertNotNull($movie->poster_path);
+        Storage::disk('public')->assertExists($movie->poster_path);
+    }
+}

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\Admin;
 use App\Models\Movie;
+use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
@@ -103,6 +104,28 @@ class MovieStoreTest extends TestCase
         // データベースに保存されていないことを確認
         $this->assertDatabaseMissing('movies', [
             'title' => 'テスト映画',
+        ]);
+    }
+
+    /**
+     * 一般ユーザーは管理者映画登録できないこと
+     */
+    public function test_general_user_cannot_store_movie(): void
+    {
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $user */
+        $user = User::factory()->create();
+        $this->actingAs($user, 'web');
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => 'ユーザー禁止映画',
+            'genre' => 3,
+            'description' => '一般ユーザーからのアクセスは拒否されるべきです。',
+        ]);
+
+        $response->assertRedirect(route('admin.login'));
+
+        $this->assertDatabaseMissing('movies', [
+            'title' => 'ユーザー禁止映画',
         ]);
     }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -183,4 +183,34 @@ class MovieStoreTest extends TestCase
             'title' => '無効ジャンル映画',
         ]);
     }
+
+    /**
+     * 不正なポスター画像では映画を登録できないこと
+     */
+    public function test_validation_fails_with_invalid_poster_file(): void
+    {
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $invalidPoster = UploadedFile::fake()->create('poster.txt', 100, 'text/plain');
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => '不正ポスター映画',
+            'genre' => 1,
+            'description' => 'ポスターが画像形式でない場合のテストです。',
+            'poster' => $invalidPoster,
+        ]);
+
+        // バリデーションエラーでリダイレクトされることを確認
+        $response->assertRedirect();
+
+        // poster フィールドのエラーを確認
+        $response->assertSessionHasErrors(['poster']);
+
+        // データベースに保存されていないことを確認
+        $this->assertDatabaseMissing('movies', [
+            'title' => '不正ポスター映画',
+        ]);
+    }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -156,4 +156,31 @@ class MovieStoreTest extends TestCase
             'title' => '',
         ]);
     }
+
+    /**
+     * 不正なジャンルでは映画を登録できないこと
+     */
+    public function test_validation_fails_with_invalid_genre(): void
+    {
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => '無効ジャンル映画',
+            'genre' => 999,
+            'description' => 'ジャンルが不正な場合のテストです。',
+        ]);
+
+        // バリデーションエラーでリダイレクトされることを確認
+        $response->assertRedirect();
+
+        // genre フィールドのエラーを確認
+        $response->assertSessionHasErrors(['genre']);
+
+        // データベースに保存されていないことを確認
+        $this->assertDatabaseMissing('movies', [
+            'title' => '無効ジャンル映画',
+        ]);
+    }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -128,4 +128,32 @@ class MovieStoreTest extends TestCase
             'title' => 'ユーザー禁止映画',
         ]);
     }
+
+    /**
+     * 必須項目が未入力の場合、登録できないこと
+     */
+    public function test_validation_fails_when_required_fields_are_missing(): void
+    {
+        /** @var \Illuminate\Contracts\Auth\Authenticatable $admin */
+        $admin = Admin::factory()->create();
+        $this->actingAs($admin, 'admin');
+
+        $response = $this->post(route('admin.movies.store'), [
+            // 必須項目を全て空で送信
+            'title' => '',
+            'genre' => '',
+            'description' => '',
+        ]);
+
+        // バリデーションエラーでリダイレクトされることを確認
+        $response->assertRedirect();
+
+        // バリデーションエラーがセッションに保持されていることを確認
+        $response->assertSessionHasErrors(['title', 'genre', 'description']);
+
+        // データベースに保存されていないことを確認
+        $this->assertDatabaseMissing('movies', [
+            'title' => '',
+        ]);
+    }
 }

--- a/src/tests/Feature/Admin/MovieStoreTest.php
+++ b/src/tests/Feature/Admin/MovieStoreTest.php
@@ -85,4 +85,24 @@ class MovieStoreTest extends TestCase
             'poster_path' => null,  // poster_path が null であることを確認
         ]);
     }
+
+    /**
+     * 未認証ユーザーは映画を登録できないこと
+     */
+    public function test_unauthenticated_user_cannot_store_movie(): void
+    {
+        $response = $this->post(route('admin.movies.store'), [
+            'title' => 'テスト映画',
+            'genre' => 1,
+            'description' => 'テスト説明',
+        ]);
+
+        // ログインページにリダイレクトされることを確認
+        $response->assertRedirect(route('admin.login'));
+
+        // データベースに保存されていないことを確認
+        $this->assertDatabaseMissing('movies', [
+            'title' => 'テスト映画',
+        ]);
+    }
 }


### PR DESCRIPTION
### 概要
管理者側の映画登録機能に対するFeatureテストを追加
正常系・異常系の両方を実装し、認証・バリデーション・画像アップロード処理の動作確認

### 実施内容
* 映画登録の正常系テストを追加
  * ポスター画像ありで登録できること
  * ポスター画像なしで登録できること
* 映画登録の異常系テストを追加
  * 未ログインユーザーは登録できないこと
  * 一般ユーザーは登録できないこと
  * 必須項目未入力時にバリデーションエラーとなること
  * 不正なジャンル値では登録できないこと
  * 画像以外のファイルはアップロードできないこと
  * サイズ上限を超える画像はアップロードできないこと
* Docker環境のGD拡張設定を見直し、JPEG形式のダミー画像生成に対応
### 備考

